### PR TITLE
solution

### DIFF
--- a/app/create_file.py
+++ b/app/create_file.py
@@ -1,1 +1,123 @@
-# write your code here
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+USAGE = (
+    "Usage:\n"
+    "  python create_file.py -d dir1 dir2 ...\n"
+    "  python create_file.py -f file.txt\n"
+    "  python create_file.py -d dir1 dir2 -f file.txt\n\n"
+    "Notes:\n"
+    "  - After -d pass each directory name as a separate argument.\n"
+    "  - After -f pass exactly one filename.\n"
+    "  - You will be prompted for lines until you type: stop\n"
+)
+
+
+def parse_args(argv: List[str]) -> Tuple[List[str], Optional[str]]:
+    if not argv:
+        print(USAGE)
+        sys.exit(1)
+
+    dir_parts: List[str] = []
+    file_name: Optional[str] = None
+    i = 0
+
+    while i < len(argv):
+        token = argv[i]
+        if token == "-d":
+            i += 1
+            if i >= len(argv) or argv[i].startswith("-"):
+                print("Error: provide at least one directory name after -d.\n")
+                print(USAGE)
+                sys.exit(1)
+            while i < len(argv) and not argv[i].startswith("-"):
+                dir_parts.append(argv[i])
+                i += 1
+            continue
+
+        if token == "-f":
+            i += 1
+            if i >= len(argv) or argv[i].startswith("-"):
+                print("Error: provide a filename after -f.\n")
+                print(USAGE)
+                sys.exit(1)
+            if file_name is not None:
+                print("Error: -f specified more than once.\n")
+                sys.exit(1)
+            file_name = argv[i]
+            i += 1
+            continue
+
+        print(f"Error: unknown argument '{token}'.\n")
+        print(USAGE)
+        sys.exit(1)
+
+    if not dir_parts and not file_name:
+        print("Error: you must pass -d and/or -f.\n")
+        print(USAGE)
+        sys.exit(1)
+
+    return dir_parts, file_name
+
+
+def ensure_dirs(dir_parts: List[str]) -> str:
+    """Create nested directories under CWD and return absolute path."""
+    if not dir_parts:
+        return os.getcwd()
+    path = os.path.join(os.getcwd(), *dir_parts)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def collect_lines() -> List[str]:
+    """Read lines from stdin until the user types 'stop' (case-insensitive)."""
+    lines: List[str] = []
+    while True:
+        try:
+            line = input("Enter content line: ")
+        except EOFError:
+            break
+        if line.strip().lower() == "stop":
+            break
+        lines.append(line)
+    return lines
+
+
+def append_block(file_path: str, lines: List[str]) -> None:
+    """Append a timestamped, numbered block to file_path."""
+    if not lines:
+        open(file_path, "a", encoding="utf-8").close()
+        return
+
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    need_blank = os.path.exists(file_path) and os.path.getsize(file_path) > 0
+
+    with open(file_path, "a", encoding="utf-8") as f:
+        if need_blank:
+            f.write("\n")
+        f.write(f"{timestamp}\n")
+        for idx, text in enumerate(lines, 1):
+            f.write(f"{idx} {text}\n")
+
+
+def main() -> None:
+    dir_parts, file_name = parse_args(sys.argv[1:])
+    base_dir = ensure_dirs(dir_parts)
+
+    if file_name is None:
+        print(f"Created directory: {base_dir}")
+        return
+
+    file_path = os.path.join(base_dir, file_name)
+    lines = collect_lines()
+    append_block(file_path, lines)
+    print(f"Written to: {file_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,88 @@
+# tests/test_main.py
+import os
+import re
+import io
+import builtins
+import types
+
+import pytest
+
+from app.create_file import parse_args, ensure_dirs, append_block
+
+
+def test_parse_args_dirs_only():
+    dparts, fname = parse_args(["-d", "dir1", "dir2"])
+    assert dparts == ["dir1", "dir2"]
+    assert fname is None
+
+
+def test_parse_args_file_only():
+    dparts, fname = parse_args(["-f", "file.txt"])
+    assert dparts == []
+    assert fname == "file.txt"
+
+
+def test_parse_args_dirs_and_file():
+    dparts, fname = parse_args(["-d", "a", "b", "-f", "x.txt"])
+    assert dparts == ["a", "b"]
+    assert fname == "x.txt"
+
+
+def test_parse_args_errors():
+    with pytest.raises(SystemExit):
+        parse_args([])  # no flags
+    with pytest.raises(SystemExit):
+        parse_args(["-d"])  # no dir after -d
+    with pytest.raises(SystemExit):
+        parse_args(["-f"])  # no file after -f
+    with pytest.raises(SystemExit):
+        parse_args(["-f", "a.txt", "-f", "b.txt"])  # duplicate -f
+    with pytest.raises(SystemExit):
+        parse_args(["--weird"])  # unknown flag
+
+
+def test_ensure_dirs_creates_nested(tmp_path, monkeypatch):
+    # work from tmp dir to avoid touching real CWD
+    monkeypatch.chdir(tmp_path)
+    base = ensure_dirs(["dir1", "dir2"])
+    assert os.path.isdir(base)
+    assert base.endswith(os.path.join("dir1", "dir2"))
+
+
+def test_append_block_creates_and_appends(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    file_path = tmp_path / "file.txt"
+
+    # 1st write
+    append_block(str(file_path), ["Line1 content", "Line2 content", "Line3 content"])
+    text1 = file_path.read_text(encoding="utf-8")
+    # first line is timestamp
+    first_line = text1.splitlines()[0]
+    assert re.match(r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}$", first_line)
+    # numbered lines
+    assert "1 Line1 content" in text1
+    assert "2 Line2 content" in text1
+    assert "3 Line3 content" in text1
+
+    # 2nd write (append)
+    append_block(str(file_path), ["Another line1", "Another line2"])
+    text2 = file_path.read_text(encoding="utf-8")
+    # There should be a blank line separating two blocks
+    assert "\n\n" in text2
+    blocks = text2.strip().split("\n\n")
+    assert len(blocks) == 2
+
+    # In the second block, numbering must restart from 1
+    second_block = blocks[1].splitlines()
+    assert re.match(r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}$", second_block[0])
+    assert second_block[1] == "1 Another line1"
+    assert second_block[2] == "2 Another line2"
+
+
+def test_append_block_empty_lines_creates_file_only(tmp_path, monkeypatch):
+    """No lines => file should be created/touched but remain empty."""
+    monkeypatch.chdir(tmp_path)
+    p = tmp_path / "empty.txt"
+    append_block(str(p), [])
+    assert p.exists()
+    assert p.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
A command-line Python app that creates directories and files from terminal flags and appends timestamped, numbered content.

-d treats all following args as nested directory names and creates them (e.g., -d dir1 dir2).

-f takes a filename, then prompts for lines until you type stop; it writes a timestamp on top and numbers each line, appending as a new block if the file already exists.

Using both (-d ... -f file.txt) creates the directories and writes the file inside them.

Examples:
python create_file.py -f notes.txt • python create_file.py -d dir1 dir2 • python create_file.py -d dir1 dir2 -f notes.txt